### PR TITLE
Fix an accidentally hard-coded value in `xyz_from_name()`

### DIFF
--- a/webmo/util.py
+++ b/webmo/util.py
@@ -9,7 +9,7 @@ def xyz_from_name(name):
         Returns:
             A string containing the molecule's XYZ-formatted geometry.
         """
-    results = pcp.get_compounds('aspirin', 'name', record_type='3d')
+    results = pcp.get_compounds(name, 'name', record_type='3d')
     if (len(results) == 0):
         raise ValueError("Specified molecule could not be found in PubChem")
 


### PR DESCRIPTION
Fix a small bug in the new util subpackage where the name variable of the `xyz_from_name()` function was never being passed to pubchempy, resulting in only geometries for aspirin ever being returned.