### PR TITLE
Fix _arb_gaussian

### DIFF
--- a/webmo/spectrum.py
+++ b/webmo/spectrum.py
@@ -347,7 +347,7 @@ def _arb_gaussian(center, intensity, width=10):
     from math import sqrt, pi, exp, log
 
     sigma = (width / (2 * sqrt(2 * log(2))))
-    l = lambda x: intensity * (1/sigma*sqrt(2*pi)) * exp(-((x-center)**2/(2*sigma**2)))
+    l = lambda x: intensity * (1/(sigma*sqrt(2*pi))) * exp(-((x-center)**2/(2*sigma**2)))
 
     return l
 


### PR DESCRIPTION
Due to an operator precedence error, _arb_gaussian() was returning values sqrt(2*pi) times larger than they should have been. This has been fixed.